### PR TITLE
install.packages expects character

### DIFF
--- a/source/workshop_1_mcmc_en_brms.Rmd
+++ b/source/workshop_1_mcmc_en_brms.Rmd
@@ -770,7 +770,7 @@ Andere packages die van pas kunnen komen bij het controleren van MCMC convergent
 
 ```         
 # voorbeeld
-install.packages(mcmcplots)
+install.packages("mcmcplots")
 mcmcplots::mcmcplot(as.mcmc(fit_normal1, pars = parameters))
 ```
 


### PR DESCRIPTION
I noticed an install.packages() call that uses an object that doesn't exist, it's just some missing parenthesis really :) 

```r
install.packages("mcmcplots")
```

instead of 

```r
install.packages(mcmcplots)
```